### PR TITLE
Ontology wf filter display bug corrected

### DIFF
--- a/server/templates/workflows_index.html
+++ b/server/templates/workflows_index.html
@@ -309,7 +309,7 @@ function getMenuChildren(obj,parent_id) {
 	$("#"+parent_id).append(subTree);
 }
 
-function getSubLevel(uid, pid=None, name=None) {
+function getSubLevel(uid, pid, name) {
 	
 	if(ont_selections.indexOf(uid) > -1) {
 		$("#"+uid).find('>ul').slideToggle();


### PR DESCRIPTION
Ontology workflow filter links should now display.  (I noticed the triangles next to parent links are missing due to a deprecated jquery function - I plan to correct this while I enhance the overall filtering feature.)