### PR TITLE
modified db/addMetadata to allow metadata to be added to dataobjects

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -1043,12 +1043,15 @@ def addMetadata(json_request,dn):
     q=textwrap.dedent("""\
              SELECT w_guid  AS uid, 'workflow'   AS type FROM workflow   WHERE w_guid=%s UNION
              SELECT a_guid  AS uid, 'activity'   AS type FROM activity   WHERE a_guid=%s UNION
-             SELECT doi_guid AS uid, 'dataobject_instance' AS type FROM dataobject_instance WHERE doi_guid=%s
+             SELECT do_guid  AS uid, 'dataobject' AS type FROM dataobject   WHERE do_guid=%s UNION
+             SELECT doi_guid AS uid, 'dataobject_instance' AS type FROM dataobject_instance
+             WHERE doi_guid=%s
               """)
     pid=objs['parent_uid']
-    v=(pid,pid,pid)
+    v=(pid,pid,pid,pid)
     cursor.execute(q,v)
     records = cursor.fetchone()
+    if not records: raise ValueError('No record found for adding metadata.')
 
     #insert record
     md_guid = str(uuid.uuid4())


### PR DESCRIPTION
As we discussed, we are going to use user specified metadata to track checksums of file objects to see newly added dataobjects are copies or not. This has to be attached to the dataobject, not this instance. The db method was not including the dataobject table. 

Also throws an exception if no object is found to add metadata to.

